### PR TITLE
Remove duplicate SpeedInsights component from _document.tsx

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -9,7 +9,6 @@ export default function Document() {
         <Main />
         <SpeedInsights />
         <NextScript />
-        <SpeedInsights />
       </body>
     </Html>
   );


### PR DESCRIPTION
This pull request makes a minor update to the custom `_document.tsx` file by removing a duplicate usage of the `SpeedInsights` component, ensuring it is only rendered once.